### PR TITLE
Specify conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: gene-ontology
+channels:
+  - conda-forge
+dependencies:
+  - conda-forge::networkx=2.2
+  - conda-forge::numpy=1.15.3
+  - conda-forge::pandas=0.23.4
+  - conda-forge::python=3.6.7
+  - conda-forge::requests=2.20.0
+  - conda-forge::notebook=5.7.0
+  - conda-forge::nbconvert=5.4.0
+  - conda-forge::ipykernel=5.1.0
+  - pip:
+    - obonet==0.2.3


### PR DESCRIPTION
Adds an anaconda environment spec

This spec was tested by ensuring the following commands complete with no errors:

```
conda env create -f environment.yml
source activate gene-ontology
./code/run.sh
```