### PR TITLE
 Upgrade conda environment and update 'process.ipynb' for compatibility with newer Networkx  version

### DIFF
--- a/code/process.ipynb
+++ b/code/process.ipynb
@@ -12,7 +12,8 @@
     "import pandas\n",
     "import networkx\n",
     "\n",
-    "import utilities"
+    "import utilities\n",
+    "from math import gcd\n"
    ]
   },
   {
@@ -387,7 +388,7 @@
     "        key = 'direct_not_annotations' if utilities.is_NOT_qaulifier(row.Qualifier) else 'direct_annotations'\n",
     "\n",
     "        gene = row['GeneID']\n",
-    "        graph.node[go_id][key].add(gene)\n",
+    "        graph.nodes[go_id][key].add(gene)\n",
     "    \n",
     "    return graph"
    ]
@@ -401,12 +402,12 @@
     "def propagate_annotations(graph):\n",
     "    \"\"\"Infer annotations through propagations\"\"\"\n",
     "    for node in networkx.topological_sort(graph):\n",
-    "        data = graph.node[node]\n",
+    "        data = graph.nodes[node]\n",
     "        inferred = data['inferred_annotations']\n",
     "        inferred -= data['direct_not_annotations']\n",
     "        inferred |= data['direct_annotations']\n",
     "        for subsuming_node in graph.successors(node):\n",
-    "            subsuming_data = graph.node[subsuming_node]\n",
+    "            subsuming_data = graph.nodes[subsuming_node]\n",
     "            subsuming_data['inferred_annotations'] |= inferred"
    ]
   },
@@ -628,7 +629,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -642,7 +643,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -2,13 +2,13 @@ name: gene-ontology
 channels:
   - conda-forge
 dependencies:
-  - conda-forge::networkx=2.2
-  - conda-forge::numpy=1.15.3
-  - conda-forge::pandas=0.23.4
-  - conda-forge::python=3.6.7
-  - conda-forge::requests=2.20.0
-  - conda-forge::notebook=5.7.0
-  - conda-forge::nbconvert=5.4.0
-  - conda-forge::ipykernel=5.1.0
+  - conda-forge::networkx=2.6
+  - conda-forge::numpy=1.24.3
+  - conda-forge::pandas=2.0.3
+  - conda-forge::python=3.8.19
+  - conda-forge::requests=2.32.3
+  - conda-forge::notebook=7.2.1
+  - conda-forge::nbconvert=7.16.4
+  - conda-forge::ipykernel=6.29.5
   - pip:
-    - obonet==0.2.3
+    - obonet==1.1.0


### PR DESCRIPTION
refs https://github.com/dhimmel/gene-ontology/issues/6

This pull request includes the following updates and changes:

1. Conda Environment Update:
The `environment.yml` file has been upgraded to include updated packages due to availability issues. You can review the changes in the following commit:[ae04e74](https://github.com/NegarJanani/gene-ontology/commit/ae04e74d6ae725f776b60e61bf0d0a4e73d98567).
Updated Packages:

```
conda-forge::networkx=2.6
conda-forge::numpy=1.24.3
conda-forge::pandas=2.0.3
conda-forge::python=3.8.19
conda-forge::requests=2.32.3
conda-forge::notebook=7.2.1
conda-forge::nbconvert=7.16.4
Pip Packages:
obonet==1.1.0
```
You can view the relevant lines [here](https://github.com/NegarJanani/gene-ontology/blob/gh-pages/environment.yml#L5-L12).

2. Minor Changes in `process.ipynb`:
Small adjustments were made in the process.ipynb notebook to align with the newer version of Networkx. These changes can be seen in the following lines:

Line 390: 
`graph.node[go_id][key].add(gene)\n` changed to `graph.nodes[go_id][key].add(gene)\n`
Lines 404 and 409 were similarly adjusted.
The specific commit for these changes can be reviewed [here](https://github.com/NegarJanani/gene-ontology/commit/ae04e74d6ae725f776b60e61bf0d0a4e73d98567#diff-64fbd7e57a9e015844713252165033cda867e66518f1fc59b105ed0b57b3b369L390).